### PR TITLE
Remove join_args from direnv dump

### DIFF
--- a/direnv.rc
+++ b/direnv.rc
@@ -31,7 +31,7 @@ function use_flox() {
         return 1
     fi
 
-    direnv_load flox activate "$@" -- "$(join_args "$direnv" dump)"
+    direnv_load flox activate "$@" -- "$direnv" dump
 
     if [[ $# == 0 ]]; then
         watch_dir ".flox"


### PR DESCRIPTION
This was failing for me (using zsh, if relevant) as follows:

    /nix/store/izq9x8j1ym13wk0ggb12hn8x1mbjfk4r-bash-5.2-p15/bin/bash: line 1: /run/current-system/sw/bin/direnv dump : No such file or directory

Wrapping the command with `set -x` showed that it's quoting the arguments with the binary and treating it as a single command:

    ++ flox activate -- '/run/current-system/sw/bin/direnv dump '