### PR TITLE
more specific watch condition

### DIFF
--- a/direnv.rc
+++ b/direnv.rc
@@ -34,6 +34,8 @@ function use_flox() {
     direnv_load flox activate "$@" -- "$direnv" dump
 
     if [[ $# == 0 ]]; then
-        watch_file ".flox/env/manifest.lock"
+        watch_dir ".flox/env/"
+        watch_file ".flox/env.json"
+        watch_file ".flox/env.lock"
     fi
 }

--- a/direnv.rc
+++ b/direnv.rc
@@ -34,6 +34,6 @@ function use_flox() {
     direnv_load flox activate "$@" -- "$direnv" dump
 
     if [[ $# == 0 ]]; then
-        watch_file ".flox/env.json"
+        watch_file ".flox/env/manifest.lock"
     fi
 }

--- a/direnv.rc
+++ b/direnv.rc
@@ -34,6 +34,6 @@ function use_flox() {
     direnv_load flox activate "$@" -- "$direnv" dump
 
     if [[ $# == 0 ]]; then
-        watch_dir ".flox"
+        watch_file ".flox/env.json"
     fi
 }


### PR DESCRIPTION
This prevents `flox activate` from running on every command execution while in a directory with this extension activated.

I believe `.flox` is a much more dynamic directory than it may have been in the past. If we watch `.flox/env.json` I believe that should change every time the environment meaningfully changes?